### PR TITLE
avoid duplicate header

### DIFF
--- a/src/model/model.pri
+++ b/src/model/model.pri
@@ -29,7 +29,7 @@ PRIV_HEADERS += $$INCDIR/ircchannel_p.h
 PRIV_HEADERS += $$INCDIR/ircuser_p.h
 PRIV_HEADERS += $$INCDIR/ircusermodel_p.h
 
-HEADERS += $$PUB_HEADERS
+#HEADERS += $$PUB_HEADERS
 HEADERS += $$PRIV_HEADERS
 
 SOURCES += $$PWD/ircbuffer.cpp


### PR DESCRIPTION
Avoids warnings like:

`warning: duplicate script for target "moc_ircbuffer.cpp" ignored`

and

```
warning: overriding recipe for target 'moc_ircbuffer.cpp'
warning: ignoring old recipe for target 'moc_ircbuffer.cpp'
```

and doesn't seem to cause issues. Perhaps all `PUB_HEADERS` lines should be removed too.