### PR TITLE
Added preAuthMessage property

### DIFF
--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -55,6 +55,7 @@ class IRC_CORE_EXPORT IrcConnection : public QObject
     Q_PROPERTY(QString userName READ userName WRITE setUserName NOTIFY userNameChanged)
     Q_PROPERTY(QString nickName READ nickName WRITE setNickName NOTIFY nickNameChanged)
     Q_PROPERTY(QString realName READ realName WRITE setRealName NOTIFY realNameChanged)
+    Q_PROPERTY(QByteArray preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
     Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
     Q_PROPERTY(QStringList nickNames READ nickNames WRITE setNickNames NOTIFY nickNamesChanged)
     Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged)
@@ -102,6 +103,9 @@ public:
 
     QString realName() const;
     void setRealName(const QString& name);
+
+    QByteArray preAuthMessage() const;
+    void setPreAuthMessage(const QByteArray& preAuthMessage);
 
     QString password() const;
     void setPassword(const QString& password);
@@ -223,6 +227,7 @@ Q_SIGNALS:
     void userNameChanged(const QString& name);
     void nickNameChanged(const QString& name);
     void realNameChanged(const QString& name);
+    void preAuthMessageChanged(const QByteArray& preAuthMessage);
     void passwordChanged(const QString& password);
     void nickNamesChanged(const QStringList& names);
     void displayNameChanged(const QString& name);

--- a/include/IrcCore/ircconnection.h
+++ b/include/IrcCore/ircconnection.h
@@ -55,7 +55,7 @@ class IRC_CORE_EXPORT IrcConnection : public QObject
     Q_PROPERTY(QString userName READ userName WRITE setUserName NOTIFY userNameChanged)
     Q_PROPERTY(QString nickName READ nickName WRITE setNickName NOTIFY nickNameChanged)
     Q_PROPERTY(QString realName READ realName WRITE setRealName NOTIFY realNameChanged)
-    Q_PROPERTY(QByteArray preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
+    Q_PROPERTY(QString preAuthMessage READ preAuthMessage WRITE setPreAuthMessage NOTIFY preAuthMessageChanged)
     Q_PROPERTY(QString password READ password WRITE setPassword NOTIFY passwordChanged)
     Q_PROPERTY(QStringList nickNames READ nickNames WRITE setNickNames NOTIFY nickNamesChanged)
     Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged)
@@ -104,8 +104,8 @@ public:
     QString realName() const;
     void setRealName(const QString& name);
 
-    QByteArray preAuthMessage() const;
-    void setPreAuthMessage(const QByteArray& preAuthMessage);
+    QString preAuthMessage() const;
+    void setPreAuthMessage(const QString& preAuthMessage);
 
     QString password() const;
     void setPassword(const QString& password);
@@ -227,7 +227,7 @@ Q_SIGNALS:
     void userNameChanged(const QString& name);
     void nickNameChanged(const QString& name);
     void realNameChanged(const QString& name);
-    void preAuthMessageChanged(const QByteArray& preAuthMessage);
+    void preAuthMessageChanged(const QString& preAuthMessage);
     void passwordChanged(const QString& password);
     void nickNamesChanged(const QStringList& names);
     void displayNameChanged(const QString& name);

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,7 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
-    QByteArray preAuthMessage = "";
+    QByteArray preAuthMessage;
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,6 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
+    QByteArray preAuthMessage = "";
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/include/IrcCore/ircconnection_p.h
+++ b/include/IrcCore/ircconnection_p.h
@@ -91,7 +91,7 @@ public:
     QString userName;
     QString nickName;
     QString realName;
-    QByteArray preAuthMessage;
+    QString preAuthMessage;
     QString password;
     QStringList nickNames;
     QString displayName;

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -872,6 +872,25 @@ void IrcConnection::setRealName(const QString& name)
 }
 
 /*!
+  This property holds message which will be sent to server before passing password while authenticating.
+ */
+
+QByteArray IrcConnection::preAuthMessage() const
+{
+    Q_D(const IrcConnection);
+    return d->preAuthMessage;
+}
+
+void IrcConnection::setPreAuthMessage(const QByteArray &preAuthMessage)
+{
+    Q_D(IrcConnection);
+    if (d->preAuthMessage != preAuthMessage){
+        d->preAuthMessage = preAuthMessage;
+        emit preAuthMessageChanged(preAuthMessage);
+    }
+}
+
+/*!
     This property holds the password.
 
     \par Access functions:

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -875,7 +875,7 @@ void IrcConnection::setRealName(const QString& name)
   This property holds message which will be sent to server before passing password while authenticating.
  */
 
-QByteArray IrcConnection::preAuthMessage() const
+QString IrcConnection::preAuthMessage() const
 {
     Q_D(const IrcConnection);
     return d->preAuthMessage;

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -881,7 +881,7 @@ QByteArray IrcConnection::preAuthMessage() const
     return d->preAuthMessage;
 }
 
-void IrcConnection::setPreAuthMessage(const QByteArray &preAuthMessage)
+void IrcConnection::setPreAuthMessage(const QString& preAuthMessage)
 {
     Q_D(IrcConnection);
     if (d->preAuthMessage != preAuthMessage){

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -872,7 +872,14 @@ void IrcConnection::setRealName(const QString& name)
 }
 
 /*!
-  This property holds message which will be sent to server before passing password while authenticating.
+    This property holds a message which will be sent to server before password while authenticating.
+
+    \par Access functions:
+    \li QString <b>preAuthMessage</b>() const
+    \li void <b>setPreAuthMessage</b>(const QString& preAuthMessage)
+
+    \par Notifier signal:
+    \li void <b>preAuthMessageChanged</b>(const QString& preAuthMessage)
  */
 
 QString IrcConnection::preAuthMessage() const

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -103,7 +103,7 @@ void IrcProtocolPrivate::authenticate(bool secure)
             const QByteArray data = userName + '\0' + userName + '\0' + password.toUtf8();
             authed = connection->sendData("AUTHENTICATE " + data.toBase64());
         } else {
-            if (!preAuthMessage.isEmpty()){
+            if (!preAuthMessage.isEmpty()) {
                 connection->sendRaw(preAuthMessage);
             }
             authed = connection->sendRaw(QString("PASS :%1").arg(password));

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -97,15 +97,15 @@ void IrcProtocolPrivate::authenticate(bool secure)
 {
     const QString password = connection->password();
     const QString preAuthMessage = connection->preAuthMessage();
+    if (!preAuthMessage.isEmpty()) {
+        connection->sendRaw(preAuthMessage);
+    }
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();
             const QByteArray data = userName + '\0' + userName + '\0' + password.toUtf8();
             authed = connection->sendData("AUTHENTICATE " + data.toBase64());
         } else {
-            if (!preAuthMessage.isEmpty()) {
-                connection->sendRaw(preAuthMessage);
-            }
             authed = connection->sendRaw(QString("PASS :%1").arg(password));
         }
     }

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -96,7 +96,7 @@ IrcProtocolPrivate::IrcProtocolPrivate()
 void IrcProtocolPrivate::authenticate(bool secure)
 {
     const QString password = connection->password();
-    const QByteArray preAuthMessage = connection->preAuthMessage();
+    const QString preAuthMessage = connection->preAuthMessage();
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -96,12 +96,16 @@ IrcProtocolPrivate::IrcProtocolPrivate()
 void IrcProtocolPrivate::authenticate(bool secure)
 {
     const QString password = connection->password();
+    const QByteArray preAuthMessage = connection->preAuthMessage();
     if (!password.isEmpty()) {
         if (secure) {
             const QByteArray userName = connection->userName().toUtf8();
             const QByteArray data = userName + '\0' + userName + '\0' + password.toUtf8();
             authed = connection->sendData("AUTHENTICATE " + data.toBase64());
         } else {
+            if (!preAuthMessage.isEmpty()){
+                connection->sendRaw(preAuthMessage);
+            }
             authed = connection->sendRaw(QString("PASS :%1").arg(password));
         }
     }


### PR DESCRIPTION
This makes it possible to send `CAP REQ` message before passing `PASS` and `NICK`, which makes it possible to recive `GLOBALUSERSTATE` message.