### PR TITLE
Prepare CMake for Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Network)
+find_package(Qt${MAJOR_QT_VERSION} REQUIRED COMPONENTS Core Network)
+
+if (BUILD_WITH_QT6)
+    find_package(Qt${MAJOR_QT_VERSION} REQUIRED COMPONENTS Core5Compat)
+endif()
 
 set(LibCommuni_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/include/")
 set(LibCommuni_SOURCE_DIR  "${CMAKE_CURRENT_LIST_DIR}/src/")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -63,7 +63,15 @@ set_property(SOURCE ircfilter.cpp PROPERTY SKIP_AUTOMOC ON)
 
 add_library(${PROJECT_NAME} STATIC ${PRIV_HEADERS} ${PUB_HEADERS} ${SOURCE_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Network)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    Qt${MAJOR_QT_VERSION}::Core
+    Qt${MAJOR_QT_VERSION}::Network
+    )
+if (BUILD_WITH_QT6)
+    target_link_libraries(${PROJECT_NAME} PUBLIC
+        Qt${MAJOR_QT_VERSION}::Core5Compat
+        )
+endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "${LibCommuni_INCLUDE_DIR}/IrcCore/")
 target_compile_definitions(${PROJECT_NAME} PUBLIC IRC_STATIC IRC_NAMESPACE=Communi)
 

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -42,7 +42,15 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} STATIC ${PUB_HEADERS} ${PRIV_HEADERS} ${SOURCE_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Network)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    Qt${MAJOR_QT_VERSION}::Core
+    Qt${MAJOR_QT_VERSION}::Network
+    )
+if (BUILD_WITH_QT6)
+    target_link_libraries(${PROJECT_NAME} PUBLIC
+        Qt${MAJOR_QT_VERSION}::Core5Compat
+        )
+endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "${LibCommuni_INCLUDE_DIR}/IrcModel/" "${LibCommuni_INCLUDE_DIR}/IrcCore/")
 target_compile_definitions(${PROJECT_NAME} PUBLIC IRC_STATIC IRC_NAMESPACE=Communi)
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -44,7 +44,15 @@ set(SOURCE_FILES
 
 add_library(${PROJECT_NAME} STATIC ${PUB_HEADERS} ${PRIV_HEADERS} ${SOURCE_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Network)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    Qt${MAJOR_QT_VERSION}::Core
+    Qt${MAJOR_QT_VERSION}::Network
+    )
+if (BUILD_WITH_QT6)
+    target_link_libraries(${PROJECT_NAME} PUBLIC
+        Qt${MAJOR_QT_VERSION}::Core5Compat
+        )
+endif()
 target_include_directories(${PROJECT_NAME} PUBLIC "${LibCommuni_INCLUDE_DIR}/IrcUtil/" "${LibCommuni_INCLUDE_DIR}/IrcModel/" "${LibCommuni_INCLUDE_DIR}/IrcCore/")
 target_compile_definitions(${PROJECT_NAME} PUBLIC IRC_STATIC IRC_NAMESPACE=Communi)
 


### PR DESCRIPTION
While compiling with Qt6 we need to use Qt6::Qt5Compat module too.

Requires Chatterino/chatterino2#3103
