### PR TITLE
Update CMake version from 3.8 to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 
-project(LibCommuni VERSION 3.6.0)
+project(LibCommuni VERSION 3.7.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -8,6 +8,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
+
+option(BUILD_WITH_QT6 "Build with Qt6" On)
+
+if (BUILD_WITH_QT6)
+    set(MAJOR_QT_VERSION "6")
+else()
+    set(MAJOR_QT_VERSION "5")
+endif()
 
 find_package(Qt${MAJOR_QT_VERSION} REQUIRED COMPONENTS Core Network)
 


### PR DESCRIPTION
I saw the following notice in chatterino, so I thought, I'd just PR a fix.
```
CMake Deprecation Warning at lib/libcommuni/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

I don't know how to actually test it in Chatterino yet (idk about how submodules work), so I just built the library itself.

The BUILD_WITH_QT6 stuff seemed to be necessary to not get the following error anymore:
```
CMake Error at CMakeLists.txt:16 (find_package):
  By not providing "FindQt.cmake" in CMAKE_MODULE_PATH this project has asked
  CMake to find a package configuration file provided by "Qt", but CMake did
  not find one.

  Could not find a package configuration file provided by "Qt" with any of
  the following names:

    QtConfig.cmake
    qt-config.cmake

  Add the installation prefix of "Qt" to CMAKE_PREFIX_PATH or set "Qt_DIR" to
  a directory containing one of the above files.  If "Qt" provides a separate
  development package or SDK, be sure it has been installed.
```