### PR TITLE
fix: include mocs in top-level namespace

### DIFF
--- a/src/core/irc.cpp
+++ b/src/core/irc.cpp
@@ -239,6 +239,6 @@ QDebug operator<<(QDebug debug, Irc::SortMethod method)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_irc.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_irc.cpp"

--- a/src/core/irccommand.cpp
+++ b/src/core/irccommand.cpp
@@ -926,6 +926,6 @@ QDebug operator<<(QDebug debug, const IrcCommand* command)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_irccommand.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_irccommand.cpp"

--- a/src/core/ircconnection.cpp
+++ b/src/core/ircconnection.cpp
@@ -1754,6 +1754,6 @@ QDebug operator<<(QDebug debug, const IrcConnection* connection)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_ircconnection.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircconnection.cpp"

--- a/src/core/ircmessage.cpp
+++ b/src/core/ircmessage.cpp
@@ -2367,6 +2367,6 @@ QDebug operator<<(QDebug debug, const IrcMessage* message)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_ircmessage.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircmessage.cpp"

--- a/src/core/ircmessagecomposer.cpp
+++ b/src/core/ircmessagecomposer.cpp
@@ -256,6 +256,6 @@ void IrcMessageComposer::replaceParam(int index, const QString& param)
 }
 #endif // IRC_DOXYGEN
 
-#include "moc_ircmessagecomposer_p.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircmessagecomposer_p.cpp"

--- a/src/core/ircnetwork.cpp
+++ b/src/core/ircnetwork.cpp
@@ -774,6 +774,6 @@ QDebug operator<<(QDebug debug, const IrcNetwork* network)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_ircnetwork.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircnetwork.cpp"

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -587,6 +587,6 @@ void IrcProtocol::setActiveCapabilities(const QSet<QString>& capabilities)
     priv->setActiveCapabilities(capabilities);
 }
 
-#include "moc_ircprotocol.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircprotocol.cpp"

--- a/src/model/ircbuffer.cpp
+++ b/src/model/ircbuffer.cpp
@@ -642,6 +642,6 @@ QDebug operator<<(QDebug debug, const IrcBuffer* buffer)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_ircbuffer.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircbuffer.cpp"

--- a/src/model/ircbuffermodel.cpp
+++ b/src/model/ircbuffermodel.cpp
@@ -1421,7 +1421,8 @@ bool IrcBufferModel::restoreState(const QByteArray& state, int version)
     return true;
 }
 
+IRC_END_NAMESPACE
+
 #include "moc_ircbuffermodel.cpp"
 #include "moc_ircbuffermodel_p.cpp"
 
-IRC_END_NAMESPACE

--- a/src/model/ircchannel.cpp
+++ b/src/model/ircchannel.cpp
@@ -669,6 +669,6 @@ QDebug operator<<(QDebug debug, const IrcChannel* channel)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_ircchannel.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircchannel.cpp"

--- a/src/model/ircuser.cpp
+++ b/src/model/ircuser.cpp
@@ -273,6 +273,6 @@ QDebug operator<<(QDebug debug, const IrcUser* user)
 }
 #endif // QT_NO_DEBUG_STREAM
 
-#include "moc_ircuser.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircuser.cpp"

--- a/src/model/ircusermodel.cpp
+++ b/src/model/ircusermodel.cpp
@@ -761,6 +761,6 @@ bool IrcUserModel::lessThan(IrcUser* one, IrcUser* another, Irc::SortMethod meth
     return n1.compare(n2, Qt::CaseInsensitive) < 0;
 }
 
-#include "moc_ircusermodel.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircusermodel.cpp"

--- a/src/util/irccommandparser.cpp
+++ b/src/util/irccommandparser.cpp
@@ -599,6 +599,6 @@ void IrcCommandParser::reset()
     setTarget(QString());
 }
 
-#include "moc_irccommandparser.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_irccommandparser.cpp"

--- a/src/util/irccommandqueue.cpp
+++ b/src/util/irccommandqueue.cpp
@@ -244,7 +244,7 @@ void IrcCommandQueue::flush()
     d->_irc_sendBatch(true);
 }
 
+IRC_END_NAMESPACE
+
 #include "moc_irccommandqueue.cpp"
 #include "moc_irccommandqueue_p.cpp"
-
-IRC_END_NAMESPACE

--- a/src/util/irccompleter.cpp
+++ b/src/util/irccompleter.cpp
@@ -407,6 +407,6 @@ void IrcCompleter::reset()
     d->completions.clear();
 }
 
-#include "moc_irccompleter.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_irccompleter.cpp"

--- a/src/util/irclagtimer.cpp
+++ b/src/util/irclagtimer.cpp
@@ -244,7 +244,7 @@ void IrcLagTimer::setInterval(int seconds)
     }
 }
 
+IRC_END_NAMESPACE
+
 #include "moc_irclagtimer.cpp"
 #include "moc_irclagtimer_p.cpp"
-
-IRC_END_NAMESPACE

--- a/src/util/ircpalette.cpp
+++ b/src/util/ircpalette.cpp
@@ -523,6 +523,6 @@ void IrcPalette::setColorName(int color, const QString& name)
     d->colors.insert(color, name);
 }
 
-#include "moc_ircpalette.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_ircpalette.cpp"

--- a/src/util/irctextformat.cpp
+++ b/src/util/irctextformat.cpp
@@ -530,6 +530,6 @@ void IrcTextFormat::parse(const QString& text)
     d->parse(text, &d->plainText, &d->html, &d->urls);
 }
 
-#include "moc_irctextformat.cpp"
-
 IRC_END_NAMESPACE
+
+#include "moc_irctextformat.cpp"


### PR DESCRIPTION
The current way breaks builds on Qt 6.9.0.