### PR TITLE
fix: use `.sliced` over `.mid`

### DIFF
--- a/src/core/ircmessage_p.cpp
+++ b/src/core/ircmessage_p.cpp
@@ -41,7 +41,7 @@ QString IrcMessagePrivate::prefix() const
     if (!m_prefix.isExplicit() && m_prefix.isNull() && !data.prefix.isNull()) {
         if (data.prefix.startsWith(':')) {
             if (data.prefix.length() > 1)
-                m_prefix = QString::fromUtf8(QByteArrayView(data.prefix).mid(1));
+                m_prefix = QString::fromUtf8(QByteArrayView(data.prefix).sliced(1));
         } else {
             // empty (not null)
             m_prefix = QString("");


### PR DESCRIPTION
Qt 6.4 doesn't have `QByteArrayView::mid`. Found in https://github.com/Chatterino/chatterino2/pull/6500. `QByteArrayView::mid` is deprecated anyway, so use `.sliced`.