### PR TITLE
fix(ci): Coverage and pin macOS to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [master, chatterino-cmake]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         config: [shared, static]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         qt-version: [6.7.*]
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         config: [shared, static]
         os: [ubuntu-latest, macos-latest, windows-latest]
         qt-version: [6.7.*]
+      fail-fast: false
 
     steps:
     - name: Install Qt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Enable Developer Command Prompt
-      uses: Chatterino/msvc-dev-cmd@v2
+      uses: Chatterino/msvc-dev-cmd@v2.0.5
       if: matrix.os == 'windows-latest'
 
     - name: Build

--- a/src/module_build.pri
+++ b/src/module_build.pri
@@ -45,9 +45,7 @@ coverage {
     capture.file = ../../coverage/$${IRC_MODULE}.cov
     capture.commands = @mkdir -p ../../coverage
     capture.commands += && lcov --base-directory $$_PRO_FILE_PWD_ --directory \$(OBJECTS_DIR) --capture --output-file $$capture.file
-    capture.filters = \"/usr/*\" \"moc_*.cpp\" \"*3rdparty/*\" \"*QtCore/*\" \"*QtNetwork/*\" \"*corelib/*\" \"*network/*\"
-    !isEqual(IRC_MODULE, "IrcCore"):capture.filters += \"*/IrcCore/*\"
-    !isEqual(IRC_MODULE, "IrcModel"):capture.filters += \"*/IrcModel/*\"
+    capture.filters = \"/usr/*\" \"moc_*.cpp\"
     capture.commands += && lcov --remove $$capture.file $$capture.filters --output-file $$capture.file
     QMAKE_EXTRA_TARGETS += capture
 


### PR DESCRIPTION
Lcov complains about unused excludes, so remove them.

Not sure if that's already done, but we need a `CODECOV_TOKEN` secret in this repo.