### PR TITLE
refactor: Abstract tags in a `TagsRef` proxy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+# This is an approximation on the style used by libcommuni.
+---
+BasedOnStyle: Microsoft
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: false
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+ColumnLimit: 180

--- a/include/IrcCore/IrcTagsRef
+++ b/include/IrcCore/IrcTagsRef
@@ -1,0 +1,1 @@
+#include <irctagsref.h>

--- a/include/IrcCore/ircglobal.h
+++ b/include/IrcCore/ircglobal.h
@@ -114,4 +114,15 @@
 
 #endif // IRC_NAMESPACE
 
+#if __has_cpp_attribute(gsl::Pointer)
+#define IRC_GSL_POINTER [[gsl::Pointer]]
+#else
+#define IRC_GSL_POINTER
+#endif
+#if __has_cpp_attribute(clang::lifetimebound)
+#define IRC_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define IRC_LIFETIMEBOUND
+#endif
+
 #endif // IRCGLOBAL_H

--- a/include/IrcCore/ircmessage.h
+++ b/include/IrcCore/ircmessage.h
@@ -31,6 +31,7 @@
 
 #include <Irc>
 #include <IrcGlobal>
+#include <IrcTagsRef>
 #include <QtCore/qobject.h>
 #include <QtCore/qvariant.h>
 #include <QtCore/qmetatype.h>
@@ -62,7 +63,6 @@ class IRC_CORE_EXPORT IrcMessage : public QObject
     Q_PROPERTY(QString account READ account)
     Q_PROPERTY(QStringList parameters READ parameters WRITE setParameters)
     Q_PROPERTY(QDateTime timeStamp READ timeStamp WRITE setTimeStamp)
-    Q_PROPERTY(QVariantMap tags READ tags WRITE setTags)
     Q_ENUMS(Type Flag)
     Q_FLAGS(Flags)
 
@@ -144,11 +144,11 @@ public:
     QDateTime timeStamp() const;
     void setTimeStamp(const QDateTime& timeStamp);
 
-    QVariantMap tags() const;
+    TagsRef tags() const IRC_LIFETIMEBOUND;
     void setTags(const QVariantMap& tags);
 
     QVariant tag(const QString& name) const;
-    void setTag(const QString& name, const QVariant& tag);
+    void setTag(const QString& name, const QString& value);
 
     Q_INVOKABLE QByteArray toData() const;
     Q_INVOKABLE static IrcMessage* fromData(const QByteArray& data, IrcConnection* connection);

--- a/include/IrcCore/ircmessage_p.h
+++ b/include/IrcCore/ircmessage_p.h
@@ -29,6 +29,7 @@
 #ifndef IRCMESSAGE_P_H
 #define IRCMESSAGE_P_H
 
+#include <IrcTagsRef>
 #include <QtCore/qmap.h>
 #include <QtCore/qlist.h>
 #include <QtCore/qstring.h>
@@ -54,6 +55,12 @@ public:
 
     const T& value() const { return v; }
     void setValue(const T& value) { v = value; exp = true; null = false; }
+
+    T &mutate() {
+      exp = true;
+      null = false;
+      return v;
+    }
 
     void clear() { v = T(); exp = false; null = true; }
 
@@ -99,8 +106,10 @@ public:
     QString param(int index) const;
     void setParams(const QStringList& params);
 
-    QVariantMap tags() const;
+    TagsRef tags() const IRC_LIFETIMEBOUND;
     void setTags(const QVariantMap& tags);
+
+    void insertTag(const QString &name, const QString &value);
 
     QByteArray content() const;
 

--- a/include/IrcCore/irctagsref.h
+++ b/include/IrcCore/irctagsref.h
@@ -34,17 +34,6 @@
 
 IRC_BEGIN_NAMESPACE
 
-#if __has_cpp_attribute(gsl::Pointer)
-#define IRC_GSL_POINTER [[gsl::Pointer]]
-#else
-#define IRC_GSL_POINTER
-#endif
-#if __has_cpp_attribute(clang::lifetimebound)
-#define IRC_LIFETIMEBOUND [[clang::lifetimebound]]
-#else
-#define IRC_LIFETIMEBOUND
-#endif
-
 /// A reference/view type for tags of an IRC message.
 ///
 /// This should be passed by value, similar to a string view.

--- a/include/IrcCore/irctagsref.h
+++ b/include/IrcCore/irctagsref.h
@@ -1,0 +1,86 @@
+/*
+  Copyright (C) 2008-2026 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCTAGSREF_H
+#define IRCTAGSREF_H
+
+#include <IrcGlobal>
+#include <QVariantMap>
+
+IRC_BEGIN_NAMESPACE
+
+#if __has_cpp_attribute(gsl::Pointer)
+#define IRC_GSL_POINTER [[gsl::Pointer]]
+#else
+#define IRC_GSL_POINTER
+#endif
+#if __has_cpp_attribute(clang::lifetimebound)
+#define IRC_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define IRC_LIFETIMEBOUND
+#endif
+
+/// A reference/view type for tags of an IRC message.
+///
+/// This should be passed by value, similar to a string view.
+/// Conceptually, this is a typedef to `const MapType &`.
+struct IRC_GSL_POINTER TagsRef
+{
+    using MapType = QVariantMap;
+
+    /// Create a reference to a map.
+    ///
+    /// The created reference must not outlive `map`.
+    explicit TagsRef(const MapType &map IRC_LIFETIMEBOUND);
+
+    /// Get the raw map pointer.
+    ///
+    /// Avoid using this - use the helper functions in this type.
+    const MapType &raw() const;
+
+    /// Get a tag by its name. If it doesn't exist, `std::nullopt` is returned.
+    [[nodiscard]] std::optional<QString> get(const QString &tag) const;
+
+    /// Get a tag by its name or a fallback. If it doesn't exist in the map, use `other`.
+    [[nodiscard]] QString getOr(const QString &tag, const QString &other) const;
+
+    /// Get a tag by its name or an empty string if it doesn't exist.
+    [[nodiscard]] QString getOrEmpty(const QString &tag) const;
+
+    /// Check if a tag was specified.
+    [[nodiscard]] bool has(const QString &tag) const;
+
+  private:
+    // Stored as a pointer instead of a reference to generate the implicit copy/move ctors.
+    // This is never null.
+    const MapType *storage;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCTAGSREF_H

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CONV_HEADERS
         ${LibCommuni_INCLUDE_DIR}/IrcCore/IrcMessageFilter
         ${LibCommuni_INCLUDE_DIR}/IrcCore/IrcNetwork
         ${LibCommuni_INCLUDE_DIR}/IrcCore/IrcProtocol
+        ${LibCommuni_INCLUDE_DIR}/IrcCore/IrcTagsRef
         )
 
 set(PUB_HEADERS
@@ -28,6 +29,7 @@ set(PUB_HEADERS
         ${LibCommuni_INCLUDE_DIR}/IrcCore/ircmessage.h
         ${LibCommuni_INCLUDE_DIR}/IrcCore/ircnetwork.h
         ${LibCommuni_INCLUDE_DIR}/IrcCore/ircprotocol.h
+        ${LibCommuni_INCLUDE_DIR}/IrcCore/irctagsref.h
         )
 
 set(PRIV_HEADERS
@@ -50,6 +52,7 @@ set(SOURCE_FILES
         ${CMAKE_CURRENT_LIST_DIR}/ircmessagecomposer.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ircnetwork.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ircprotocol.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/irctagsref.cpp
         #${LibCommuni_SOURCE_DIR}/3rdparty/mozilla/rdf_utils.c
         )
 

--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -19,6 +19,7 @@ CONV_HEADERS += $$INCDIR/IrcMessage
 CONV_HEADERS += $$INCDIR/IrcMessageFilter
 CONV_HEADERS += $$INCDIR/IrcNetwork
 CONV_HEADERS += $$INCDIR/IrcProtocol
+CONV_HEADERS += $$INCDIR/IrcTagsRef
 
 PUB_HEADERS  = $$INCDIR/irc.h
 PUB_HEADERS += $$INCDIR/irccommand.h
@@ -29,6 +30,7 @@ PUB_HEADERS += $$INCDIR/ircglobal.h
 PUB_HEADERS += $$INCDIR/ircmessage.h
 PUB_HEADERS += $$INCDIR/ircnetwork.h
 PUB_HEADERS += $$INCDIR/ircprotocol.h
+PUB_HEADERS += $$INCDIR/irctagsref.h
 
 PRIV_HEADERS  = $$INCDIR/irccommand_p.h
 PRIV_HEADERS += $$INCDIR/ircconnection_p.h
@@ -51,3 +53,4 @@ SOURCES += $$PWD/ircmessage_p.cpp
 SOURCES += $$PWD/ircmessagecomposer.cpp
 SOURCES += $$PWD/ircnetwork.cpp
 SOURCES += $$PWD/ircprotocol.cpp
+SOURCES += $$PWD/irctagsref.cpp

--- a/src/core/ircmessage.cpp
+++ b/src/core/ircmessage.cpp
@@ -533,7 +533,7 @@ QString IrcMessage::host() const
 QString IrcMessage::account() const
 {
     Q_D(const IrcMessage);
-    return d->tags().value(QStringLiteral("account")).toString();
+    return d->tags().getOrEmpty(QStringLiteral("account"));
 }
 
 /*!
@@ -611,12 +611,12 @@ void IrcMessage::setTimeStamp(const QDateTime& timeStamp)
     This property holds the message tags.
 
     \par Access functions:
-    \li QVariantMap <b>tags</b>() const
+    \li TagsRef <b>tags</b>() const
     \li void <b>setTags</b>(const QVariantMap& tags)
 
     \sa \ref ircv3
  */
-QVariantMap IrcMessage::tags() const
+TagsRef IrcMessage::tags() const
 {
     Q_D(const IrcMessage);
     return d->tags();
@@ -638,7 +638,7 @@ void IrcMessage::setTags(const QVariantMap& tags)
 QVariant IrcMessage::tag(const QString& name) const
 {
     Q_D(const IrcMessage);
-    return d->tags().value(name);
+    return d->tags().getOrEmpty(name);
 }
 
 /*!
@@ -648,12 +648,10 @@ QVariant IrcMessage::tag(const QString& name) const
 
     \sa \ref ircv3
  */
-void IrcMessage::setTag(const QString& name, const QVariant& value)
+void IrcMessage::setTag(const QString& name, const QString& value)
 {
     Q_D(IrcMessage);
-    QVariantMap tags = d->tags();
-    tags.insert(name, value);
-    d->setTags(tags);
+    d->insertTag(name, value);
 }
 
 /*!

--- a/src/core/ircmessage_p.cpp
+++ b/src/core/ircmessage_p.cpp
@@ -112,7 +112,7 @@ void IrcMessagePrivate::setParams(const QStringList& params)
     m_params.setValue(params);
 }
 
-QVariantMap IrcMessagePrivate::tags() const
+TagsRef IrcMessagePrivate::tags() const
 {
     if (!m_tags.isExplicit() && m_tags.isNull() && !data.tags.isEmpty()) {
         QVariantMap tags;
@@ -121,12 +121,17 @@ QVariantMap IrcMessagePrivate::tags() const
             tags.insert(QString::fromUtf8(it.key()), QString::fromUtf8(it.value()));
         m_tags = tags;
     }
-    return m_tags.value();
+    return TagsRef(m_tags.value());
 }
 
 void IrcMessagePrivate::setTags(const QVariantMap& tags)
 {
     m_tags.setValue(tags);
+}
+
+void IrcMessagePrivate::insertTag(const QString& name, const QString &value)
+{
+    m_tags.mutate().insert(name, value);
 }
 
 QByteArray IrcMessagePrivate::content() const
@@ -136,9 +141,9 @@ QByteArray IrcMessagePrivate::content() const
 
         // format <tags>
         QStringList tt;
-        const QVariantMap t = tags();
-        for (QVariantMap::const_iterator it = t.begin(); it != t.end(); ++it)
-            tt += it.key() + QLatin1Char('=') + it.value().toString();
+        const auto t = tags();
+        for (const auto &[key, value] : t.raw().asKeyValueRange())
+            tt += key + QLatin1Char('=') + value.toString();
         if (!tt.isEmpty())
             data += '@' + tt.join(QLatin1String(";")).toUtf8() + ' ';
 

--- a/src/core/ircprotocol.cpp
+++ b/src/core/ircprotocol.cpp
@@ -169,7 +169,7 @@ void IrcProtocolPrivate::processLine(const QByteArray& line)
 
 bool IrcProtocolPrivate::batchMessage(IrcMessage* msg)
 {
-    QString tag = msg->tags().value("batch").toString();
+    QString tag = msg->tags().getOrEmpty("batch");
     IrcBatchMessage* batch = batches.value(tag);
     if (batch) {
         msg->setParent(batch);

--- a/src/core/irctagsref.cpp
+++ b/src/core/irctagsref.cpp
@@ -1,0 +1,77 @@
+/*
+  Copyright (C) 2008-2026 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "irctagsref.h"
+
+IRC_BEGIN_NAMESPACE
+
+TagsRef::TagsRef(const MapType &map) : storage(std::addressof(map))
+{
+}
+
+const TagsRef::MapType &TagsRef::raw() const
+{
+    return *this->storage;
+}
+
+std::optional<QString> TagsRef::get(const QString &tag) const
+{
+    auto it = this->storage->find(tag);
+    if (it != this->storage->end())
+    {
+        return it->toString();
+    }
+    return {};
+}
+
+QString TagsRef::getOr(const QString &tag, const QString &other) const
+{
+    auto it = this->storage->find(tag);
+    if (it != this->storage->end())
+    {
+        return it->toString();
+    }
+    return other;
+}
+
+QString TagsRef::getOrEmpty(const QString &tag) const
+{
+    auto it = this->storage->find(tag);
+    if (it != this->storage->end())
+    {
+        return it->toString();
+    }
+    return {};
+}
+
+bool TagsRef::has(const QString &tag) const
+{
+    return this->storage->contains(tag);
+}
+
+IRC_END_NAMESPACE

--- a/tests/auto/ircmessage/tst_ircmessage.cpp
+++ b/tests/auto/ircmessage/tst_ircmessage.cpp
@@ -222,23 +222,38 @@ void tst_IrcMessage::testTags()
 
     IrcConnection connection;
     IrcMessage* message = IrcMessage::fromData("@aaa=bbb;ccc;example.com/ddd=eee :nick!ident@host.com PRIVMSG me :Hello", &connection);
-    QCOMPARE(message->tags(), tags);
+    QCOMPARE(message->tags().raw(), tags);
+
+    QVERIFY(message->tags().has("aaa"));
+    QCOMPARE(message->tags().get("aaa"), "bbb");
+    QCOMPARE(message->tags().getOr("aaa", "foo"), "bbb");
+    QCOMPARE(message->tags().getOrEmpty("aaa"), "bbb");
+
+    QVERIFY(message->tags().has("ccc"));
+    QCOMPARE(message->tags().get("ccc"), "");
+    QCOMPARE(message->tags().getOr("ccc", "foo"), "");
+    QCOMPARE(message->tags().getOrEmpty("ccc"), "");
+
+    QVERIFY(!message->tags().has("ddd"));
+    QCOMPARE(message->tags().get("ddd"), std::nullopt);
+    QCOMPARE(message->tags().getOr("ddd", "foo"), "foo");
+    QCOMPARE(message->tags().getOrEmpty("ddd"), "");
 
     tags.insert(QStringLiteral("ccc"), "xyz");
     message->setTag(QStringLiteral("ccc"), "xyz");
 
-    QCOMPARE(message->tags(), tags);
+    QCOMPARE(message->tags().raw(), tags);
     QCOMPARE(message->toData(), QByteArray("@aaa=bbb;ccc=xyz;example.com/ddd=eee :nick!ident@host.com PRIVMSG me Hello"));
 
     tags.insert(QStringLiteral("fff"), "ggg");
     message->setTag(QStringLiteral("fff"), "ggg");
-    QCOMPARE(message->tags(), tags);
+    QCOMPARE(message->tags().raw(), tags);
     QCOMPARE(message->toData(), QByteArray("@aaa=bbb;ccc=xyz;example.com/ddd=eee;fff=ggg :nick!ident@host.com PRIVMSG me Hello"));
 
     tags.clear();
     tags.insert(QStringLiteral("foo"), "bar");
     message->setTags(tags);
-    QCOMPARE(message->tags(), tags);
+    QCOMPARE(message->tags().raw(), tags);
     QCOMPARE(message->toData(), QByteArray("@foo=bar :nick!ident@host.com PRIVMSG me Hello"));
 }
 
@@ -1061,7 +1076,7 @@ void tst_IrcMessage::testClone()
     QCOMPARE(clone->connection(), &connection);
     QCOMPARE(clone->type(), pm->type());
     QCOMPARE(clone->flags(), pm->flags());
-    QCOMPARE(clone->tags(), pm->tags());
+    QCOMPARE(clone->tags().raw(), pm->tags().raw());
     QCOMPARE(clone->prefix(), pm->prefix());
     QCOMPARE(clone->nick(), pm->nick());
     QCOMPARE(clone->ident(), pm->ident());


### PR DESCRIPTION
There are two goals of this PR:
1. Make getting tags more expressive. Specifically getting empty default values was mostly implicit with the old approach. `msg->tags()["mytag"].toString()` would yield an empty string if the tag didn't exist. With this PR, it becomes `msg->tags().getOrEmpty("mytag")`.
2. Allow changing the map type without users needing to update. Right now, the map is a `QVariantMap`. However, it only stores strings. Furthermore, we could make the tag names (map key) a `QUtf8StringView`, as it's always a view into the original source - no escaping happens. 

I also added a `.clang-format` for format-on-save users (me).